### PR TITLE
Load and apply SF-GWAS relatedness mask

### DIFF
--- a/config/gwas/configLocal.Party1.toml
+++ b/config/gwas/configLocal.Party1.toml
@@ -14,6 +14,9 @@ sample_keep_file = "example_data/party1/sample_keep.txt"  # need to work with --
 snp_ids_file = "example_data/party1/snp_ids.txt"          # must be unique IDs
 geno_count_file = "example_data/party1/all.gcount.transpose.bin"
 
+## SF-Relate parameters
+relatedness_mask_file = "example_data/party1/encrypted/rel_mask.bin"
+
 ## Output and cache paths
 output_dir = "out/party1"
 cache_dir = "cache/party1"

--- a/config/gwas/configLocal.Party2.toml
+++ b/config/gwas/configLocal.Party2.toml
@@ -14,6 +14,9 @@ sample_keep_file = "example_data/party2/sample_keep.txt"  # need to work with --
 snp_ids_file = "example_data/party2/snp_ids.txt"          # must be unique IDs
 geno_count_file = "example_data/party2/all.gcount.transpose.bin"
 
+## SF-Relate parameters
+relatedness_mask_file = "example_data/party2/encrypted/rel_mask.bin"
+
 ## Output and cache paths
 output_dir = "out/party2"
 cache_dir = "cache/party2"

--- a/gwas/assoc.go
+++ b/gwas/assoc.go
@@ -414,6 +414,8 @@ func (ast *AssocTest) GenoBlockMult(b int, mat crypto.CipherMatrix) (matOut cryp
 
 			matOut = crypto.ConcatCipherMatrix(outMult)
 
+			applyRelMaskToMatrix(ast.general, matOut)
+
 		} else {
 			matOut, dosageSum, dosageSqSum = MatMult4Stream(cryptoParams, mat, XBlock, 5, true, 0)
 
@@ -546,6 +548,7 @@ func (ast *AssocTest) GetAssociationStats() (crypto.CipherVector, []bool) {
 		ynew[0] = mpcObj.Network.BootstrapVecAll(cryptoParams, ynew[0])
 		ynew[0] = crypto.CMultConst(cryptoParams, ynew[0], -1.0, true)
 		ynew[0] = crypto.CPAdd(cryptoParams, ynew[0], y)
+		ynew[0] = applyRelMaskToVector(ast.general, ynew[0])
 
 		log.LLvl1(time.Now().Format(time.RFC3339), "ynew computed")
 

--- a/gwas/gwas.go
+++ b/gwas/gwas.go
@@ -32,6 +32,9 @@ type ProtocolInfo struct {
 	cov            *mat.Dense
 	pos            []uint64
 
+	// Optional relatedness mask
+	relMask crypto.CipherVector
+
 	gwasParams *GWASParams
 
 	config *Config
@@ -108,6 +111,8 @@ type Config struct {
 	Debug          bool  `toml:"debug"`
 	BlocksForAssoc []int `toml:"blocks_for_assoc_test"`
 	PgenBatchSize  int   `toml:"pgen_batch_nsnp"`
+
+	RelatednessMaskFile string `toml:"relatedness_mask_file"`
 }
 
 func (prot *ProtocolInfo) IsBlockForAssocTest(blockId int) bool {
@@ -269,7 +274,7 @@ func InitializeGWASProtocol(config *Config, pid int, mpcOnly bool) (gwasProt *Pr
 
 	gwasParams := InitGWASParams(config.NumInds, config.NumSnps, config.NumCovs, config.NumPCs, config.SnpDistThres)
 
-	return &ProtocolInfo{
+	gwasProt = &ProtocolInfo{
 		mpcObj: mpcEnv, // One MPC object for each thread
 		cps:    cps,
 
@@ -282,6 +287,11 @@ func InitializeGWASProtocol(config *Config, pid int, mpcOnly bool) (gwasProt *Pr
 		gwasParams: gwasParams,
 		config:     config,
 	}
+
+	if !mpcOnly && config.RelatednessMaskFile != "" {
+		gwasProt.relMask = loadEncryptedMask(cps, config.RelatednessMaskFile)
+	}
+	return
 }
 
 func (g *ProtocolInfo) Phase1() {

--- a/gwas/utilities.go
+++ b/gwas/utilities.go
@@ -527,3 +527,54 @@ func SaveIntVectorToFile(filename string, x []int) {
 
 	writer.Flush()
 }
+
+func loadEncryptedMask(cps *crypto.CryptoParams, filename string) crypto.CipherVector {
+	file, err := os.Open(filename)
+	if err != nil {
+		log.Fatal(err)
+	}
+	defer file.Close()
+
+	reader := bufio.NewReader(file)
+
+	var ncts uint32
+	if err := binary.Read(reader, binary.LittleEndian, &ncts); err != nil {
+		log.Fatal(err)
+	}
+
+	sizesBuf := make([]byte, 8*int(ncts))
+	if _, err := io.ReadFull(reader, sizesBuf); err != nil {
+		log.Fatal(err)
+	}
+
+	var ctLen uint64
+	if err := binary.Read(reader, binary.LittleEndian, &ctLen); err != nil {
+		log.Fatal(err)
+	}
+
+	ctBytes := make([]byte, ctLen)
+	if _, err := io.ReadFull(reader, ctBytes); err != nil {
+		log.Fatal(err)
+	}
+
+	return mpc.UnmarshalCV(cps, int(ncts), sizesBuf, ctBytes)
+}
+
+func applyRelMaskToMatrix(g *ProtocolInfo, mat crypto.CipherMatrix) {
+	if g.relMask == nil {
+		return
+	}
+	for i := range mat {
+		mat[i] = crypto.CMult(g.cps, mat[i], g.relMask)
+		crypto.CRescale(g.cps, mat[i])
+	}
+}
+
+func applyRelMaskToVector(g *ProtocolInfo, vec crypto.CipherVector) crypto.CipherVector {
+	if g.relMask == nil {
+		return vec
+	}
+	out := crypto.CMult(g.cps, vec, g.relMask)
+	crypto.CRescale(g.cps, out)
+	return out
+}


### PR DESCRIPTION
This PR attempts to integrate SF-GWAS and SF-Relate by loading and applying encrypted relatedness mask.

@froelich Could you please provide feedback if this is the right approach and place to do it?

Sister PR: https://github.com/froelich/sf-relate/pull/1